### PR TITLE
Replace `nom` with `winnow`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [dependencies]
 nom = "7"
 smallvec = "1.10.0"
+winnow = "0.5.28"
 
 [dev-dependencies]
 criterion = { version = "0.4", features = ["html_reports"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nom = "7"
 smallvec = "1.10.0"
 winnow = "0.5.28"
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,11 @@
 
 This is a work-in-progress library to parse a [GEDCOM 5.5.1](https://gedcom.io/specifications/ged551.pdf), which is the most commonly used file format for exchanging genealogical data.
 
-In this attempt, I am continuing to learn Rust, and learning [nom](https://docs.rs/nom/latest/nom/), to parse a gedcom into a structured data source which can then be serialized, manipulated, searched, etc.
+In this attempt, I am continuing to learn Rust, and learning ~~[nom](https://docs.rs/nom/latest/nom/)~~ [winnow](https://github.com/winnow-rs/winnow), to parse a gedcom into a structured data source which can then be serialized, manipulated, searched, etc.
 
 ## Notes
 
 I've got enough of the GEDCOM parsing that I should write a complete test suite, so I know exactly what is missing.
-
-I'm still not 100% convinced that I'm using nom correctly, but for a first pass, well, it's functional.
 
 ## Copyright
 

--- a/benches/parse_gedcom.rs
+++ b/benches/parse_gedcom.rs
@@ -3,7 +3,7 @@ use gedcom_test::parse::parse_gedcom;
 
 use std::time::Duration;
 
-const FILENAME: &str = "../data/complete.ged";
+const FILENAME: &str = "data/complete.ged";
 
 fn criterion_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("parse-gedcom");

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ mod tests {
         let gedcom = parse_gedcom("./data/complete.ged");
 
         // Test the header
-
+        // println!("Gedcom: {:?}", gedcom.header);
         // Test the copyright header
         assert!(gedcom.header.copyright.is_some());
         let copyright = gedcom.header.copyright.unwrap();

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -7,11 +7,7 @@ use std::fs::File;
 use std::io::{self, BufRead};
 use std::path::Path;
 
-// use winnow::ascii::{alpha1, alphanumeric1, digit1, line_ending, not_line_ending, space0};
-// use winnow::combinator::{delimited, opt, peek, preceded};
 use winnow::prelude::*;
-// use winnow::stream::Stream;
-// use winnow::token::{tag, take_till};
 
 /// This is pretty much a kludge to strip out U+FEFF, a Zero Width No-Break Space
 /// https://www.compart.com/en/unicode/U+FEFF

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -7,100 +7,25 @@ use std::fs::File;
 use std::io::{self, BufRead};
 use std::path::Path;
 
-// use nom::character::complete::newline;
-// use nom::character::complete::digit1;
-
-use nom::IResult;
-
-// use nom::{
-//     error::{make_error, ErrorKind, ParseError},
-//     Needed,
-// };
-// use nom::{
-//     AsChar, Compare, CompareResult, ExtendInto, InputIter, InputLength, InputTake,
-//     InputTakeAtPosition, Offset, Slice,
-// };
-// use nom::branch::alt;
-
-// use nom::bytes::complete::{take_while, take_while1};
-// use nom::character::complete::{
-//     alphanumeric1,
-//     // alpha1,
-//     // one_of,
-//     line_ending,
-//     // multispace0,
-//     // multispace1,
-//     not_line_ending,
-//     space0,
-// };
-// use nom::combinator::{
-//     // all_consuming,
-//     // map,
-//     // map_opt,
-//     map_res,
-//     opt,
-//     peek,
-//     recognize,
-//     verify,
-// };
-// use nom::sequence::{
-//     delimited,
-//     // pair,
-//     preceded,
-//     // separated_pair,
-//     // terminated,
-//     // tuple,
-// };
-// use nom::ParseTo;
-
-// /// A line of GEDCOM data
-// type Line<'a> = (
-//     u8,              // level
-//     Option<&'a str>, // xref
-//     Option<&'a str>, // tag
-//     Option<&'a str>, // value
-// );
-
-// /// nop -- just testing
-// pub fn nop(input: &str) -> IResult<&str, Line> {
-//     let line = Line {
-//         level: 0,
-//         xref: Some("adsf"),
-//         tag: "HEAD",
-//         value: Some("a value"),
-//     };
-
-//     Ok(("", line))
-// }
-
-// fn source(input: &str) -> IResult<&str, Source> {
-//     let source = Source {
-//         source: "".to_string(),
-//         name: None,
-//         version: None,
-//         address: None
-//     };
-
-//     // return IResult.ok(input, source);
-// }
-
-// fn parse_level(input: &str) -> IResult<&str, &str> {
-//     digit1(input)
-// }
+// use winnow::ascii::{alpha1, alphanumeric1, digit1, line_ending, not_line_ending, space0};
+// use winnow::combinator::{delimited, opt, peek, preceded};
+use winnow::prelude::*;
+// use winnow::stream::Stream;
+// use winnow::token::{tag, take_till};
 
 /// This is pretty much a kludge to strip out U+FEFF, a Zero Width No-Break Space
 /// https://www.compart.com/en/unicode/U+FEFF
 ///
 /// So far, I've only seen this with one GEDCOM, as the starting byte.
-pub fn zero_with_no_break_space(input: &str) -> IResult<&str, &str> {
-    if input.starts_with('\u{FEFF}') {
-        let parser = nom::bytes::complete::tag("\u{FEFF}");
+// pub fn zero_with_no_break_space(input: &mut &str) -> PResult<&str> {
+//     if input.starts_with('\u{FEFF}') {
+//         let parser = tag("\u{FEFF}");
 
-        parser(input)
-    } else {
-        Ok((input, ""))
-    }
-}
+//         parser.parse_next(input)
+//     } else {
+//         Ok("")
+//     }
+// }
 
 /// What did I mean to do with this? gg
 /// I think it takes the input and returns a tuple containing the tag and it's
@@ -111,56 +36,53 @@ pub fn zero_with_no_break_space(input: &str) -> IResult<&str, &str> {
 // }
 
 /// Read the next tag's value and any continuations
-pub fn get_tag_value(input: &str) -> IResult<&str, Option<String>> {
-    let mut text: String = String::from("");
-    let mut line;
-    let mut buffer;
+pub fn get_tag_value(input: &mut &str) -> PResult<Option<String>> {
+    let mut line = Line::parse(input).unwrap();
 
-    (buffer, line) = Line::parse(input).unwrap();
-    text += line.value;
+    // Seed the value with the initial value
+    let mut text: String = line.value.to_string();
 
-    (_, line) = Line::peek(buffer).unwrap();
+    line = Line::peek(input).unwrap();
     while line.tag == "CONC" || line.tag == "CONT" {
         // consume
-        (buffer, line) = Line::parse(buffer).unwrap();
+        line = Line::parse(input).unwrap();
 
-        // allocate
-        text += line.value;
         if line.tag == "CONT" {
             text += "\n";
+        } else {
+            text += " ";
         }
+        text += line.value;
 
         // peek ahead
-        (_, line) = Line::peek(buffer).unwrap();
+        line = Line::peek(input).unwrap();
     }
 
-    Ok((buffer, Some(text)))
+    Ok(Some(text))
 }
 
 /// Parse the buffer if the CONC tag is found and return the resulting string.
-pub fn conc(input: &str) -> IResult<&str, &str> {
-    let (buffer, line) = Line::parse(input).unwrap();
+// pub fn conc(input: &mut &str) -> PResult<Option<String>> {
+//     let line = Line::parse(input).unwrap();
 
-    if line.tag == "CONC" {
-        Ok((buffer, line.value))
-    } else {
-        Ok((buffer, ""))
-    }
-}
+//     if line.tag == "CONC" {
+//         Ok(Some(line.value.to_string()))
+//     } else {
+//         Ok(None)
+//     }
+// }
 
 /// Parse the buffer if the CONT tag is found and return the resulting string.
 /// TODO: Refactor this. It should handle CONT and CONC.
-pub fn cont(input: &str) -> IResult<&str, &str> {
-    // let line: (u8, Option<&str>, Option<&str>, Option<&str>);
-    // let buffer: &str;
-    let (buffer, line) = Line::parse(input).unwrap();
+// pub fn cont(input: &mut &str) -> PResult<Option<String>> {
+//     let line = Line::parse(input).unwrap();
 
-    if line.tag == "CONT" {
-        Ok((buffer, line.value))
-    } else {
-        Ok((buffer, ""))
-    }
-}
+//     if line.tag == "CONT" {
+//         Ok(Some(line.value.to_string()))
+//     } else {
+//         Ok(None)
+//     }
+// }
 
 /// Parse a GEDCOM file
 pub fn parse_gedcom(filename: &str) -> Gedcom {
@@ -199,50 +121,152 @@ pub fn parse_gedcom(filename: &str) -> Gedcom {
             if buffer.strip_prefix('\u{FEFF}').is_some() {
                 buffer.remove(0);
             }
+            // println!("Buffer: \n'{}'", buffer);
+            // record = buffer.clone() + "\n";
 
             if let Some(ch) = buffer.chars().next() {
                 if ch == '0' && !record.is_empty() {
-                    // We found a new record, beginning with buffer, so
-                    // process the data in `record` before continuing
+                    let mut input: &str = record.as_str();
 
-                    // Peek at the next line to see where we're at.
-                    let (buff, line) = Line::peek(&record).unwrap();
-
+                    // Peek at the first line in the record so we know how
+                    // to parse it.
+                    let line = Line::peek(&mut input).unwrap();
+                    // println!("Got a line: {:?}", line);
                     match line.tag {
                         "HEAD" => {
-                            gedcom.header = Header::parse(buff.to_string());
+                            // println!("Parsing HEAD: \n{}", input);
+                            gedcom.header = Header::parse(input.to_string());
                         }
                         "INDI" => {
-                            let indi = Individual::parse(buff.to_string());
-                            // TODO: Remove the if. This is just to clean up the output for debugging.
-                            if indi.xref.clone().unwrap() == "@I1@" {
-                                gedcom.individuals.push(indi);
-                            }
+                            // let indi = Individual::parse(buff.to_string());
+                            // // TODO: Remove the if. This is just to clean up the output for debugging.
+                            // if indi.xref.clone().unwrap() == "@I1@" {
+                            //     gedcom.individuals.push(indi);
+                            // }
                         }
                         "SOUR" => {}
                         "REPO" => {}
                         "OBJE" => {
-                            let obj = Object::parse(buff);
-                            println!("{:?}", obj);
+                            // let obj = Object::parse(buff);
+                            // println!("{:?}", obj);
                         }
                         "FAM" => {}
                         "SUBM" => {
-                            // The record of the submitter of the family tree
-                            // Not always present (it exists in complete.ged)
-                            if let Some(ref subm) = gedcom.header.submitter {
-                                if let Some(xref) = &subm.xref {
-                                    gedcom.header.submitter =
-                                        Submitter::find_by_xref(buff, xref.to_string());
-                                }
-                            }
+                            // // The record of the submitter of the family tree
+                            // // Not always present (it exists in complete.ged)
+                            // if let Some(ref subm) = gedcom.header.submitter {
+                            //     if let Some(xref) = &subm.xref {
+                            //         gedcom.header.submitter =
+                            //             Submitter::find_by_xref(buff, xref.to_string());
+                            //     }
+                            // }
                         }
                         _ => {}
                     };
 
                     record.clear();
                 }
+                record = record + &buffer.clone() + "\n";
+                // println!("Record: {:?}", record);
             }
-            record = record + &buffer.clone() + "\n";
+
+            // match Line::peek(&mut linebuff) {
+            //     Ok(line) => {
+            //         if line.level == 0 && line.tag == "HEAD" {
+            //             // Consume the line
+            //             Line::parse(&mut linebuff).unwrap();
+            //         } else if line.level == 1 {
+            //             // println!("Found an inner tag: {}", line.tag);
+            //             match line.tag {
+            //                 "CHAR" => {
+            //                     gedcom.header.encoding = Some(line.value.to_string());
+            //                     Line::parse(&mut linebuff).unwrap();
+            //                 }
+            //                 "INDI" => {
+            //                     let indi = Individual::parse(buff.to_string());
+            //                     // TODO: Remove the if. This is just to clean up the output for debugging.
+            //                     if indi.xref.clone().unwrap() == "@I1@" {
+            //                         gedcom.individuals.push(indi);
+            //                     }
+            //                 }
+            //                 "SOUR" => {}
+            //                 "REPO" => {}
+            //                 "OBJE" => {
+            //                     let obj = Object::parse(buff);
+            //                     println!("{:?}", obj);
+            //                 }
+            //                 "FAM" => {}
+            //                 "SUBM" => {
+            //                     // The record of the submitter of the family tree
+            //                     // Not always present (it exists in complete.ged)
+            //                     if let Some(ref subm) = gedcom.header.submitter {
+            //                         if let Some(xref) = &subm.xref {
+            //                             gedcom.header.submitter =
+            //                                 Submitter::find_by_xref(buff, xref.to_string());
+            //                         }
+            //                     }
+            //                 }
+            //                 _ => {
+            //                     // println!("Unhandled header tag: {}", line.tag);
+            //                     // (_, _) = Line::parse(&buffer).unwrap();
+            //                 }
+            //             };
+            //         // } else {
+            //         //     (_, _) = Line::parse(&buffer).unwrap();
+            //         }
+
+            //         // println!("line: {:?}", line);
+
+            //     }
+            //     Err(_e) => {
+            //         println!("Error parsing line: '{}'", buffer);
+            //     }
+            // }
+
+            // if let Some(ch) = buffer.chars().next() {
+            //     if ch == '0' && !record.is_empty() {
+            //         // We found a new record, beginning with buffer, so
+            //         // process the data in `record` before continuing
+
+            //         // Peek at the next line to see where we're at.
+            //         // let (buff, line) = Line::peek(&record).unwrap();
+            //         let line = Line::peek(record).unwrap();
+
+            //         match line.tag {
+            //             "HEAD" => {
+            //                 gedcom.header = Header::parse(buff.to_string());
+            //             }
+            //             "INDI" => {
+            //                 let indi = Individual::parse(buff.to_string());
+            //                 // TODO: Remove the if. This is just to clean up the output for debugging.
+            //                 if indi.xref.clone().unwrap() == "@I1@" {
+            //                     gedcom.individuals.push(indi);
+            //                 }
+            //             }
+            //             "SOUR" => {}
+            //             "REPO" => {}
+            //             "OBJE" => {
+            //                 let obj = Object::parse(buff);
+            //                 println!("{:?}", obj);
+            //             }
+            //             "FAM" => {}
+            //             "SUBM" => {
+            //                 // The record of the submitter of the family tree
+            //                 // Not always present (it exists in complete.ged)
+            //                 if let Some(ref subm) = gedcom.header.submitter {
+            //                     if let Some(xref) = &subm.xref {
+            //                         gedcom.header.submitter =
+            //                             Submitter::find_by_xref(buff, xref.to_string());
+            //                     }
+            //                 }
+            //             }
+            //             _ => {}
+            //         };
+
+            //         record.clear();
+            //     }
+            // }
+            // record = record + &buffer.clone() + "\n";
         }
         // TODO: families
         // TODO: repositories
@@ -261,4 +285,21 @@ where
 {
     let file = File::open(filename)?;
     Ok(io::BufReader::new(file).lines())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_get_tag_value() {
+        let mut input = "3 ADDR 1300 West Traverse Parkway\n4 CONT Lehi, UT 84043\n4 CONC USA";
+        let output = "1300 West Traverse Parkway\nLehi, UT 84043 USA";
+
+        let res = get_tag_value(&mut input).unwrap();
+        if let Some(value) = res {
+            assert!(output == value);
+        }
+        assert!(input.len() == 0);
+    }
 }

--- a/src/types/corporation.rs
+++ b/src/types/corporation.rs
@@ -1,5 +1,4 @@
 use super::Line;
-// use crate::parse;
 use crate::types::Address;
 
 // +1 SOUR <APPROVED_SYSTEM_ID>
@@ -25,16 +24,18 @@ impl Corporation {
             address: None,
         };
 
-        let mut line: Line;
+        let mut line: Line = Line::peek(&mut buffer).unwrap();
 
         // Verify we have a CORP record
-        (_, line) = Line::peek(buffer).unwrap();
+        // line = Line::peek(&mut buffer).unwrap();
         if line.level == 2 && line.tag == "CORP" {
-            (buffer, line) = Line::parse(buffer).unwrap();
+            line = Line::parse(&mut buffer).unwrap();
+            // (buffer, line) = Line::parse(buffer).unwrap();
             corp.name = Some(line.value.to_string());
 
             // Check if the next line contains an address struct
-            (_, line) = Line::peek(buffer).unwrap();
+            line = Line::peek(&mut buffer).unwrap();
+
             if line.level == 3 && line.tag == "ADDR" {
                 (buffer, corp.address) = Address::parse(buffer);
             }

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -18,21 +18,20 @@ impl DateTime {
         };
         let mut line: Line;
 
-        (_, line) = Line::peek(buffer).unwrap();
+        line = Line::peek(&mut buffer).unwrap();
 
-        // if line.level == 1 && line.tag == "DATE" {
         if line.tag == "DATE" {
             let parent_level = line.level;
 
             // Consume the line
-            (buffer, line) = Line::parse(buffer).unwrap();
+            line = Line::parse(&mut buffer).unwrap();
             dt.date = Some(line.value.to_string());
 
             // Check to see if we have time as a child of the date record
-            (_, line) = Line::peek(buffer).unwrap();
+            line = Line::peek(&mut buffer).unwrap();
             if line.level == parent_level + 1 && line.tag == "TIME" {
                 // Consume the line
-                (buffer, line) = Line::parse(buffer).unwrap();
+                line = Line::parse(&mut buffer).unwrap();
                 dt.time = Some(line.value.to_string());
             }
         }

--- a/src/types/gedc.rs
+++ b/src/types/gedc.rs
@@ -20,20 +20,20 @@ impl Form {
 
         let mut line: Line;
 
-        (_, line) = Line::peek(buffer).unwrap();
+        line = Line::peek(&mut buffer).unwrap();
 
         if line.tag == "FORM" {
-            (buffer, line) = Line::parse(buffer).unwrap();
+            line = Line::parse(&mut buffer).unwrap();
 
             form.name = Some(line.value.to_string());
 
             while !buffer.is_empty() {
                 // Peek the next line
-                (_, line) = Line::peek(buffer).unwrap();
+                line = Line::peek(&mut buffer).unwrap();
                 match line.tag {
                     "VERS" => {
                         // consume the line
-                        (buffer, line) = Line::parse(buffer).unwrap();
+                        line = Line::parse(&mut buffer).unwrap();
                         form.version = Some(line.value.to_string());
                     }
                     _ => {
@@ -64,21 +64,21 @@ impl Gedc {
         };
         let mut line: Line;
 
-        (_, line) = Line::peek(buffer).unwrap();
+        line = Line::peek(&mut buffer).unwrap();
 
         if line.tag == "GEDC" {
-            (buffer, _) = Line::parse(buffer).unwrap();
+            Line::parse(&mut buffer).unwrap();
 
             while !buffer.is_empty() {
                 // Peek the next line
-                (_, line) = Line::peek(buffer).unwrap();
+                line = Line::peek(&mut buffer).unwrap();
                 match line.tag {
                     "FORM" => {
                         (buffer, gedc.form) = Form::parse(buffer);
                     }
                     "VERS" => {
                         // consume the line
-                        (buffer, line) = Line::parse(buffer).unwrap();
+                        line = Line::parse(&mut buffer).unwrap();
                         gedc.version = Some(line.value.to_string());
                     }
                     _ => {

--- a/src/types/header.rs
+++ b/src/types/header.rs
@@ -69,25 +69,28 @@ impl Header {
 
         // do parser stuff here
         while !record.is_empty() {
-            let buffer: &str;
-            let line: Line;
-
-            (_, line) = Line::peek(&record).unwrap();
+            let mut buffer: &str = record.as_str();
+            let line = Line::peek(&mut buffer).unwrap();
 
             // Inspect the top-level tags only.
             if line.level == 0 && line.tag == "HEAD" {
                 // Consume the line
                 // println!("Consuming HEAD");
-                (buffer, _) = Line::parse(&record).unwrap();
+                // (buffer, _) = Line::parse(&record).unwrap();
+                Line::parse(&mut buffer).unwrap();
             } else if line.level == 1 {
                 // println!("Found an inner tag: {}", line.tag);
                 match line.tag {
                     "CHAR" => {
                         header.encoding = Some(line.value.to_string());
-                        (buffer, _) = Line::parse(&record).unwrap();
+                        // (buffer, _) = Line::parse(&record).unwrap();
+                        Line::parse(&mut buffer).unwrap();
                     }
                     "COPR" => {
-                        (buffer, header.copyright) = parse::get_tag_value(&record).unwrap();
+                        // println!("Input before copyright: '{}'", buffer);
+                        header.copyright = parse::get_tag_value(&mut buffer).unwrap();
+                        // println!("Input after copyright: '{}'", buffer);
+                        // (buffer, header.copyright) = parse::get_tag_value(&record).unwrap();
 
                         // header.copyright = Some(line.value.unwrap_or("").to_string());
                         // (buffer, _) = Line::parse(&record).unwrap();
@@ -104,23 +107,27 @@ impl Header {
                     }
                     "DEST" => {
                         header.destination = Some(line.value.to_string());
-                        (buffer, _) = Line::parse(&record).unwrap();
+                        // (buffer, _) = Line::parse(&record).unwrap();
+                        Line::parse(&mut buffer).unwrap();
                     }
                     "FILE" => {
                         header.filename = Some(line.value.to_string());
-                        (buffer, _) = Line::parse(&record).unwrap();
+                        // (buffer, _) = Line::parse(&record).unwrap();
+                        Line::parse(&mut buffer).unwrap();
                     }
                     "GEDC" => {
                         (buffer, header.gedcom_version) = Gedc::parse(&record);
                     }
                     "LANG" => {
                         header.language = Some(line.value.to_string());
-                        (buffer, _) = Line::parse(&record).unwrap();
+                        // (buffer, _) = Line::parse(&record).unwrap();
+                        Line::parse(&mut buffer).unwrap();
                     }
                     "NOTE" => {
                         // This is just parsing the value of a line, and any
                         // CONC/CONT that follows. Rewrite
-                        (buffer, header.note) = parse::get_tag_value(&record).unwrap();
+                        header.note = parse::get_tag_value(&mut buffer).unwrap();
+                        // (buffer, header.note) = parse::get_tag_value(&record).unwrap();
                         // let note: Option<Note>;
                         // (buffer, note) = Note::parse(&record);
                         // header.note = note;
@@ -133,11 +140,13 @@ impl Header {
                     }
                     _ => {
                         // println!("Unhandled header tag: {}", line.tag);
-                        (buffer, _) = Line::parse(&record).unwrap();
+                        // (buffer, _) = Line::parse(&record).unwrap();
+                        Line::parse(&mut buffer).unwrap();
                     }
                 };
             } else {
-                (buffer, _) = Line::parse(&record).unwrap();
+                // (buffer, _) = Line::parse(&record).unwrap();
+                Line::parse(&mut buffer).unwrap();
             }
 
             record = buffer.to_string();

--- a/src/types/individual/individual.rs
+++ b/src/types/individual/individual.rs
@@ -51,7 +51,10 @@ impl Individual {
         };
 
         while !record.is_empty() {
-            let (buffer, line) = Line::parse(&record).unwrap();
+            let mut buffer = record.as_str();
+            let line = Line::parse(&mut buffer).unwrap();
+
+            // let (buffer, line) = Line::parse(&record).unwrap();
 
             // If we're at the top of the record, get the xref
             // && level == 0

--- a/src/types/individual/individual.rs
+++ b/src/types/individual/individual.rs
@@ -39,7 +39,7 @@ pub struct Individual {
 
 // impl<'a> Individual<'a> {
 impl Individual {
-    pub fn parse(mut record: String) -> Individual {
+    pub fn parse(record: &mut &str) -> Individual {
         // pub fn parse(mut record: String) -> Individual {
         let mut individual = Individual {
             xref: None,
@@ -51,25 +51,27 @@ impl Individual {
         };
 
         while !record.is_empty() {
-            let mut buffer = record.as_str();
-            let line = Line::parse(&mut buffer).unwrap();
+            // let mut buffer = record.as_str();
+            let line = Line::peek(record).unwrap();
 
             // let (buffer, line) = Line::parse(&record).unwrap();
 
             // If we're at the top of the record, get the xref
             // && level == 0
+
+            // Flag to track if we should consume the next line in record
+            let mut parse = true;
+
             match line.level {
                 0 => {
-                    // if let xref = line.xref {
                     individual.xref = Some(line.xref.to_string());
-                    // }
                 }
                 _ => {
                     match line.tag {
                         "NAME" => {
-                            let (_, pn) = PersonalName::parse(&record).unwrap();
-
+                            let pn = PersonalName::parse(record).unwrap();
                             individual.names.push(pn);
+                            parse = false;
                         }
                         "SEX" => {
                             // individual.gender =
@@ -141,9 +143,13 @@ impl Individual {
                     }
                 }
             }
+            // Consume the line
+            if parse {
+                Line::parse(record).unwrap();
+            }
 
             // record = buffer.to_string();
-            record = buffer.to_string();
+            // record = buffer.to_string();
         }
 
         individual
@@ -799,7 +805,10 @@ mod tests {
         ];
 
         let buffer = data.join("\n");
-        let indi = Individual::parse(buffer);
+        let mut record = buffer.as_str();
+        let indi = Individual::parse(&mut record);
+
+        // println!("Names: {}", indi.names.len());
 
         assert_eq!(2, indi.names.len());
         assert_eq!(Some("@I1@".to_string()), indi.xref);

--- a/src/types/individual/name.rs
+++ b/src/types/individual/name.rs
@@ -83,7 +83,9 @@ impl Name {
         let mut line: Line;
 
         while !buffer.is_empty() {
-            (buffer, line) = Line::parse(buffer).unwrap();
+            line = Line::parse(&mut buffer).unwrap();
+
+            // (buffer, line) = Line::parse(buffer).unwrap();
             // println!("Name::level = {level}, tag = {tag:?}, value={value:?}");
 
             match line.tag {
@@ -120,7 +122,8 @@ impl Name {
 
             // Check if the next line is a new NAME record
             // TODO: a peek_line method so we can check level and tag in one call
-            let (_, line) = Line::parse(buffer).unwrap();
+            // let (_, line) = Line::parse(buffer).unwrap();
+            let line = Line::peek(&mut buffer).unwrap();
 
             // let level = parse::peek_level(buffer).unwrap_or(("", 0_u8)).1;
             // // let tag = Some(parse::peek_tag(buffer).unwrap().1);
@@ -238,7 +241,7 @@ impl PersonalName {
         // We're on level one, so parse until we hit another level one?
         // let min_level = 1;
 
-        let buffer: &str;
+        let mut buffer: &str;
 
         // TODO: make a Line struct?
         // let mut level: u8 = 0;
@@ -252,7 +255,9 @@ impl PersonalName {
         // level = parse::peek_level(&buffer).unwrap().1;
         // tag = Some(parse::peek_tag(&buffer).unwrap().1);
         // println!("DEBUG: Level {level}, tag {tag:?}");
-        let (mut buffer, mut line) = Line::parse(buffer).unwrap();
+        let mut line = Line::parse(&mut buffer).unwrap();
+
+        // let (mut buffer, mut line) = Line::parse(buffer).unwrap();
 
         while line.level > 1 && !buffer.is_empty() {
             if line.level == 2 {
@@ -288,7 +293,8 @@ impl PersonalName {
             if line.level == 1 {
                 break;
             } else {
-                (buffer, line) = Line::parse(buffer).unwrap();
+                // (buffer, line) = Line::parse(buffer).unwrap();
+                line = Line::parse(&mut buffer).unwrap();
             }
         }
 

--- a/src/types/line.rs
+++ b/src/types/line.rs
@@ -1,8 +1,6 @@
 // use std::str::FromStr;
 
-use winnow::ascii::{
-    alphanumeric1, digit1, line_ending, not_line_ending, space0,
-};
+use winnow::ascii::{alphanumeric1, digit1, line_ending, not_line_ending, space0};
 use winnow::combinator::{opt, preceded, separated_pair};
 use winnow::error::StrContext;
 use winnow::prelude::*;

--- a/src/types/line.rs
+++ b/src/types/line.rs
@@ -1,10 +1,13 @@
-use std::str::FromStr;
+// use std::str::FromStr;
 
-use nom::{bytes::complete::is_not, IResult};
-
-use nom::character::complete::{alphanumeric1, digit1, line_ending, not_line_ending, space0};
-use nom::combinator::{map_res, opt, recognize, verify};
-use nom::sequence::{preceded, separated_pair};
+use winnow::ascii::{
+    alphanumeric1, digit1, line_ending, not_line_ending, space0,
+};
+use winnow::combinator::{opt, preceded, separated_pair};
+use winnow::error::StrContext;
+use winnow::prelude::*;
+use winnow::stream::Stream;
+use winnow::token::{tag, take_till};
 
 /// A GEDCOM line
 /// level + delim (space) + [optional_xref_ID] + tag + [optional_line_value] + terminator
@@ -16,133 +19,225 @@ pub struct Line<'a> {
     pub value: &'a str,
 }
 
+// impl std::str::FromStr for Line {
+//     // The error must be owned
+//     type Err = String;
+
+//     fn from_str(s: &str) -> Result<Self, Self::Err> {
+//         hex_color.parse(s).map_err(|e| e.to_string())
+//     }
+// }
+
 impl<'b> Line<'b> {
-    /// Peek at the next line.
-    pub fn peek(input: &str) -> IResult<&str, Line> {
-        let (_, l) = Line::parse(input).unwrap();
-
-        Ok((input, l))
-    }
-    /// Parse a single line of GEDCOM data
-    pub fn parse(input: &str) -> IResult<&str, Line> {
-        /*
-        New strategy: let the wookie win.
-
-        Parse the whole line out of the input first. Then parse the individual elements
-        out into variables, present or not.
-
-        Lastly, return the input minus our line, and a tuple representing level, xref, tag, value
-
-        */
-
-        // let mut _level: u8 = 0;
-        // let mut _xref: &str = "";
-        // let mut _tag: &str = "";
-        // let mut _value: &str = "";
-        let is_eol: bool;
-        let mut tmp: &str = "";
-        // let mut _value: &str = "";
+    pub fn parse(input: &mut &'b str) -> PResult<Line<'b>> {
         let mut line = Line {
             level: 0,
             xref: "",
             tag: "",
             value: "",
         };
-
+        // println!("Parsing line...");
+        // println!("Starting input: '{}'", input);
         if !input.is_empty() {
-            match Line::level(input) {
-                Ok((mut buffer, _level)) => {
-                    line.level = _level;
+            // We could rewrite this into a sequence of parsers, something like this:
+            // let (level, _, xref, _, tag, delim, value) = (
+            //     Self::level,
+            //     Self::delim,
+            //     Self::xref,
+            //     Self::delim,
+            //     Self::tag,
+            //     Self::delim,
+            //     Self::value,
+            // )
+            //     .parse_next(input).unwrap();
 
-                    (buffer, _) = Line::delim(buffer).unwrap();
-                    (buffer, line.xref) = Line::xref(buffer).unwrap();
-                    (buffer, line.tag) = Line::tag(buffer.trim_start()).unwrap();
-                    (buffer, _) = Line::delim(buffer).unwrap();
-                    (buffer, is_eol) = Line::peek_eol(buffer).unwrap();
-
-                    if !is_eol {
-                        (buffer, _) = Line::delim(buffer).unwrap();
-
-                        (buffer, line.value) = Line::value(buffer).unwrap();
+            let level = Self::level(input);
+            match level {
+                Ok(lvl) => {
+                    line.level = lvl;
+                    let _ = Self::delim(input);
+                    // println!("Input after level: '{}'", input);
+                    match Self::xref(input) {
+                        Ok(xref) => {
+                            line.xref = xref;
+                        }
+                        Err(_e) => {
+                            todo!();
+                        }
                     }
+                    if !line.xref.is_empty() {
+                        let _ = Self::delim(input);
+                    }
+                    line.tag = Self::tag(input)?;
+                    let _ = Self::delim(input);
 
-                    tmp = Line::eol(buffer).unwrap_or((buffer, "")).0;
+                    // println!("Input: '{}'", input);
+                    let is_eol = Self::peek_eol(input)?;
+                    // println!("EOL: {}", is_eol);
+                    if is_eol {
+                        // println!("Eating eol");
+                        Self::eol(input).unwrap();
+                        // let _ = Self::delim(input);
+                    } else {
+                        // println!("eating delim");
+                        // Self::eol(input).unwrap();
+                        Self::delim(input).unwrap();
+                        line.value = Self::value(input)?;
+                        // println!("Input after value: '{}'", input);
+
+                        let is_eol = Self::peek_eol(input)?;
+                        if is_eol {
+                            Self::eol(input).unwrap();
+                        }
+                    }
                 }
                 Err(e) => {
-                    println!("Error parsing level: {}", e);
+                    println!("Err: {}", e);
+                    println!("Error parsing line: '{}'", input);
+                    Self::eol(input).unwrap();
+                    /*
+                    There's a case where a line is simply the extension of the
+                    previous line because of an embedded newline. This is common
+                    in Ancestry source data, IME. Technically, it's incorrect
+                    according to spec; the data should use a CONC/CONT to indicate
+                    a break on a new line.
+
+                    What we can attempt to do is parse the line as the value, as
+                    if it were a CONCatonation. We don't have a line level, nor
+                    do we know what the previous line is, so we'll set it to
+                    u8::MAX, I guess, and add a special use-case for that.
+                     */
+
+                    // line.level = u8::MAX;
+                    // line.tag = "CONC";
+                    // line.value = Self::value(input)?;
+                    // println!("New value: '{:?}'", line);
+
+                    // there's a case where the value of a line contains a newline,
+                    // breaking it into its own line. I think it's techically
+                    // invalid, according to spec; it should use CONC/CONT.
+                    // It's common in Ancestry source data so may as well work
+                    // to handle it.
                 }
             }
         }
-        Ok((tmp, line))
+        // println!("ending input: '{}'", input);
+        // println!("done. {:?}", line);
+        Ok(line)
+    }
 
-        // Ok((tmp, (_level, Some(_xref), Some(_tag), Some(_value))))
+    /// Peek ahead at the next line without consuming it.
+    pub fn peek(input: &mut &'b str) -> PResult<Line<'b>> {
+        let start = input.checkpoint();
+        let line = Line::parse(input).unwrap();
+
+        input.reset(start);
+        Ok(line)
     }
 
     /// Parse a number from the string, but return it as an actual Rust number, not a string.
-    fn level(input: &str) -> IResult<&str, u8> {
-        let mut parser = map_res(digit1, u8::from_str);
-        parser(input)
+    fn level(input: &mut &str) -> PResult<u8> {
+        // parse_to works because it uses FromStr, which is effectively
+        // a convienence function around try_map
+        // digit1.try_map(str::parse).parse_next(input)
+        digit1
+            .context(StrContext::Label("level"))
+            .parse_to()
+            .parse_next(input)
     }
 
+    /// Parse a number from the string, but return it as an actual Rust number, not a string.
+    // fn peek_level<'s>(input: &mut &'s str) -> PResult<u8> {
+    //     let start = input.checkpoint();
+
+    //     let level = Self::level(input).unwrap();
+    //     input.reset(start);
+    //     Ok(level)
+    // }
+
     /// Parse the delimiter
-    fn delim(input: &str) -> IResult<&str, &str> {
-        space0(input)
+    fn delim(input: &mut &'b str) -> PResult<&'b str> {
+        space0.context(StrContext::Label("delim")).parse_next(input)
+    }
+
+    fn eol(input: &mut &'b str) -> PResult<&'b str> {
+        // multispace0.context(StrContext::Label("eol2")).parse_next(input)
+        line_ending
+            .context(StrContext::Label("eol"))
+            .parse_next(input)
+
+        // println!("EOL start input: '{}'", input);
+        // let res = line_ending.context(StrContext::Label("eol")).parse_next(input);
+        // println!("EOL end input: '{}'", input);
+
+        // res
+    }
+
+    /// Peek at the next character to see if it's a newline
+    fn peek_eol(input: &mut &'b str) -> PResult<bool> {
+        if input.starts_with('\n') || input.starts_with("\r\n") {
+            return Ok(true);
+        }
+
+        // let start = input.checkpoint();
+        // let res = Self::eol(input);
+        // input.reset(start);
+
+        // if !res.is_err() {
+        //     let is_eol = res.unwrap();
+        //     return Ok(!is_eol.is_empty());
+        // }
+        Ok(false)
+        // let is_eol = Self::eol(input).unwrap();
+
+        // input.reset(start);
+        // Ok(!is_eol.is_empty())
+    }
+
+    fn tag(input: &mut &'b str) -> PResult<&'b str> {
+        // one of: a-zA-Z_
+        let parser = preceded(opt(tag("_")), alphanumeric1)
+            .recognize()
+            .verify(|o: &str| o.len() <= 31);
+
+        parser.context(StrContext::Label("tag")).parse_next(input)
+    }
+
+    fn value(input: &mut &'b str) -> PResult<&'b str> {
+        not_line_ending
+            .context(StrContext::Label("value"))
+            .parse_next(input)
     }
 
     /// Parse the xref, if present
     ///
     /// TODO: Return the leading/trailing @ portion of the xref
-    fn xref(input: &str) -> IResult<&str, &str> {
+    fn xref(input: &mut &'b str) -> PResult<&'b str> {
         if input.starts_with('@') {
-            let mut parser = recognize(separated_pair(
-                nom::bytes::complete::tag("@"),
-                is_not("@"),
-                nom::bytes::complete::tag("@"),
-            ));
-            parser(input)
-        } else {
-            Ok((input, ""))
+            let mut parser =
+                separated_pair(tag("@"), take_till(0.., |c| c == '@'), tag("@")).recognize();
+            return parser.parse_next(input);
+
+            // println!("Parsing xref: '{}'", input);
+            // let mut parser = delimited(tag("@"), take_till(0.., |c| c == '@'), tag("@"));
+            // let res = parser.context(StrContext::Label("xref")).parse_next(input);
+
+            // if !res.is_err() {
+            //     let mut xref = res.unwrap();
+            //     xref += "@";
+            //     return Ok("@1@");
+            // }
+            // take_till(1.., |c| c == '@').parse_next(input)
+            // let mut parser = delimited(
+            //     tag("@"),
+            //     is_not("@"),
+            //     tag("@"),
+            // );
+
+            // parser(input)
         }
+        Ok("")
     }
-
-    fn tag(input: &str) -> IResult<&str, &str> {
-        // one of: a-zA-Z_
-        // alpha1(input)
-        verify(
-            recognize(preceded(opt(nom::bytes::complete::tag("_")), alphanumeric1)),
-            |o: &str| o.len() <= 31,
-        )(input)
-    }
-
-    fn value(input: &str) -> IResult<&str, &str> {
-        not_line_ending(input)
-    }
-
-    fn eol(input: &str) -> IResult<&str, &str> {
-        line_ending(input)
-    }
-
-    /// Peek at the next character to see if it's a newline
-    fn peek_eol(input: &str) -> IResult<&str, bool> {
-        let (input, is_eol) = Line::eol(input).unwrap_or((input, ""));
-        Ok((input, !is_eol.is_empty()))
-    }
-
-    // /// Peek the level of the next line
-    // fn peek_level(input: &str) -> IResult<&str, u8> {
-    //     let mut parser = map_res(peek(digit1), u8::from_str);
-    //     parser(input)
-    // }
-
-    // /// Peek at the tag in the next line.
-    // ///
-    // /// This allows us to check what the next tag is so we can determine if we need
-    // /// to keep processing, i.e., a CONT.
-    // fn peek_tag(input: &str) -> IResult<&str, &str> {
-    //     let (_, l) = Line::parse(input).unwrap();
-
-    //     Ok((input, l.tag))
-    // }
 }
 
 #[cfg(test)]
@@ -151,7 +246,7 @@ mod tests {
 
     #[test]
     fn parse_lines() {
-        let data = vec![
+        let mut data = vec![
             "0 HEAD",
             "1 CHAR UTF-8",
             "1 SOUR Ancestry.com Family Trees",
@@ -162,28 +257,28 @@ mod tests {
             "0 @U1@ SUBM",
         ];
 
-        let (_, line) = Line::parse(data[0]).unwrap();
+        let line = Line::parse(&mut data[0]).unwrap();
         assert!(line.level == 0 && line.tag == "HEAD");
 
-        let (_, line) = Line::parse(data[1]).unwrap();
+        let line = Line::parse(&mut data[1]).unwrap();
         assert!(line.level == 1 && line.tag == "CHAR" && line.value == "UTF-8");
 
-        let (_, line) = Line::parse(data[2]).unwrap();
+        let line = Line::parse(&mut data[2]).unwrap();
         assert!(line.level == 1 && line.tag == "SOUR" && line.value == "Ancestry.com Family Trees");
 
-        let (_, line) = Line::parse(data[3]).unwrap();
+        let line = Line::parse(&mut data[3]).unwrap();
         assert!(line.level == 2 && line.tag == "DATA" && line.value == "Name of source data");
 
-        let (_, line) = Line::parse(data[4]).unwrap();
+        let line = Line::parse(&mut data[4]).unwrap();
         assert!(line.level == 3 && line.tag == "DATE" && line.value == "1 JAN 1998");
 
-        let (_, line) = Line::parse(data[5]).unwrap();
+        let line = Line::parse(&mut data[5]).unwrap();
         assert!(line.level == 3 && line.tag == "COPR" && line.value == "Copyright of source data");
 
-        let (_, line) = Line::parse(data[6]).unwrap();
+        let line = Line::parse(&mut data[6]).unwrap();
         assert!(line.level == 1 && line.tag == "SUBM" && line.value == "@U1@");
 
-        let (_, line) = Line::parse(data[7]).unwrap();
+        let line = Line::parse(&mut data[7]).unwrap();
         // TODO: Update this to include the wrapping @ when I figure out how to make nom do that.
         assert!(line.level == 0 && line.tag == "SUBM" && line.value == "" && line.xref == "@U1@");
     }

--- a/src/types/note.rs
+++ b/src/types/note.rs
@@ -12,7 +12,7 @@ impl Note {
     pub fn parse(mut buffer: &str) -> (&str, Option<Note>) {
         let mut note = Note { note: None };
 
-        (buffer, note.note) = parse::get_tag_value(buffer).unwrap();
+        note.note = parse::get_tag_value(&mut buffer).unwrap();
 
         (buffer, Some(note))
     }
@@ -33,16 +33,16 @@ mod tests {
 
         let data = vec![
             "1 NOTE This is the first line of a note.",
-            "2 CONC This is the second line of a note.",
-            "2 CONT",
+            "2 CONT This is the second line of a note.",
+            "2 CONC This is also on the second line.",
             "2 CONT This line should be the last line.",
         ];
 
         let (_, note) = Note::parse(data.join("\n").as_str());
         let n = note.unwrap().note.unwrap();
 
-        assert!(n.starts_with("This is the first line"));
-        assert!(n.ends_with("the last line.\n"));
-        assert!(n == "This is the first line of a note.This is the second line of a note.\nThis line should be the last line.\n");
+        assert!(n.starts_with("This is the first line of a note.\n"));
+        assert!(n.ends_with("the last line."));
+        assert!(n == "This is the first line of a note.\nThis is the second line of a note. This is also on the second line.\nThis line should be the last line.");
     }
 }

--- a/src/types/source.rs
+++ b/src/types/source.rs
@@ -50,24 +50,21 @@ impl Source {
         };
         let mut line: Line;
 
-        (_, line) = Line::peek(buffer).unwrap();
+        line = Line::peek(&mut buffer).unwrap();
 
         // Verify we have a SOUR record
         if line.level == 1 && line.tag == "SOUR" {
             // Consume the first line
-            (buffer, line) = Line::parse(buffer).unwrap();
+            line = Line::parse(&mut buffer).unwrap();
 
             source.source = line.value.to_string();
 
-            let (_, mut next) = Line::peek(buffer).unwrap();
-            // let (_, mut lvl) = parse::peek_level(buffer).unwrap();
+            let mut next = Line::peek(&mut buffer).unwrap();
 
             while next.level >= line.level {
-                let inner_line: Line;
-
                 // We don't want to consume the line yet because we may need
                 // the original for a parser.
-                (_, inner_line) = Line::peek(buffer).unwrap();
+                let inner_line: Line = Line::peek(&mut buffer).unwrap();
 
                 // println!("Evaluating tag: {:?}", inner_line.tag);
                 match inner_line.tag {
@@ -79,18 +76,18 @@ impl Source {
                         // but is probably not useful for anything
                         println!("Skipping _TREE");
                         // Consume the line
-                        (buffer, _) = Line::parse(buffer).unwrap();
+                        Line::parse(&mut buffer).unwrap();
                     }
                     "CORP" => {
                         (buffer, source.corporation) = Corporation::parse(buffer);
                     }
                     "NAME" => {
                         source.name = Some(inner_line.value.to_string());
-                        (buffer, _) = Line::parse(buffer).unwrap();
+                        Line::parse(&mut buffer).unwrap();
                     }
                     "VERS" => {
                         source.version = Some(inner_line.value.to_string());
-                        (buffer, _) = Line::parse(buffer).unwrap();
+                        Line::parse(&mut buffer).unwrap();
                     }
                     "DATA" => {
                         (buffer, source.data) = SourceData::parse(buffer);
@@ -99,13 +96,13 @@ impl Source {
                         println!("Unknown line: {:?}", inner_line);
 
                         // consume the line so we can parse the next
-                        (buffer, _) = Line::parse(buffer).unwrap();
+                        Line::parse(&mut buffer).unwrap();
                     }
                 }
 
                 // Peek at the next level
                 if !buffer.is_empty() {
-                    (_, next) = Line::peek(buffer).unwrap();
+                    next = Line::peek(&mut buffer).unwrap();
                     if next.level <= 1 {
                         break;
                     }

--- a/src/types/sourcedata.rs
+++ b/src/types/sourcedata.rs
@@ -22,12 +22,12 @@ impl SourceData {
         };
         let mut line: Line;
 
-        (buffer, line) = Line::peek(buffer).unwrap();
+        line = Line::peek(&mut buffer).unwrap();
         if line.tag == "DATA" {
             let lvl = line.level;
 
             // consume the line
-            (buffer, line) = Line::parse(buffer).unwrap();
+            line = Line::parse(&mut buffer).unwrap();
             data.name = Some(line.value.to_string());
 
             while line.level >= lvl {
@@ -35,7 +35,7 @@ impl SourceData {
                     break;
                 }
 
-                (buffer, line) = Line::peek(buffer).unwrap();
+                line = Line::peek(&mut buffer).unwrap();
                 if line.level == 1 {
                     // abort
                     break;
@@ -46,9 +46,7 @@ impl SourceData {
                     }
                     "COPR" => {
                         // Consume the line and get the value
-                        // (buffer, line) = parse::line(buffer).unwrap();
-                        // (buffer, data.copyright) = Copyright::parse(buffer);
-                        (buffer, data.copyright) = parse::get_tag_value(buffer).unwrap();
+                        data.copyright = parse::get_tag_value(&mut buffer).unwrap();
                     }
                     _ => {
                         break;


### PR DESCRIPTION
A small rewrite of the parsing logic, replacing `nom` with `winnow`. Benchmarking between the two reduces the average time to parse `complete.ged` from 416.11 µs to 183.21 µs (according to `cargo bench`).

