### PR TITLE
Implement comprehensive error message improvements with validation

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -279,6 +279,18 @@ Dates are a freeform field, with some common conventions. We need to implement p
    - Basic support exists
    - Complete implementation needed
 
+## Known Issues / Technical Debt
+
+### Error Handling and Validation (PR #16)
+The following validation logic branches need dedicated unit test coverage:
+- [ ] Individual validation (empty names check) - Currently only covered by integration tests
+- [ ] Family validation (empty family check) - Missing unit test for all three fields empty
+- [ ] Submitter validation (missing NAME field) - No dedicated unit test for validation branch
+- [ ] Repository validation (missing NAME field) - No test verifying ValidationError generation
+- [ ] Multimedia validation (missing FILE field) - No test verifying MissingRequiredField error
+
+Note: These validation features work correctly and are tested via integration tests, but lack isolated unit tests for better maintainability.
+
 ## Future Enhancements
 
 ### Version 0.2.0 Goals

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -290,7 +290,7 @@ Dates are a freeform field, with some common conventions. We need to implement p
 - [x] Complete NOTE record parsing (all GEDCOM 5.5.1 fields)
 - [x] Complete OBJE record parsing (all GEDCOM 5.5.1 fields)
 - [x] Complete REPO record parsing (all GEDCOM 5.5.1 fields)
-- [ ] Improved error messages
+- [x] Improved error messages (enhanced error types, validation warnings, better formatting)
 - [x] Performance optimizations for large files (minimal overhead for new record types)
 
 ### Version 0.3.0 Goals

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,29 +13,136 @@ pub enum GedcomError {
     /// Error parsing a specific line or record
     ParseError {
         line_number: Option<usize>,
+        record_type: Option<String>,
+        field: Option<String>,
         message: String,
+        context: Option<String>,
     },
 
     /// Invalid GEDCOM structure (e.g., missing required fields)
-    InvalidStructure(String),
+    InvalidStructure {
+        record_xref: Option<String>,
+        message: String,
+    },
+
+    /// Validation error for a specific field
+    ValidationError {
+        record_type: String,
+        record_xref: Option<String>,
+        field: String,
+        message: String,
+    },
+
+    /// Character encoding issues during file reading
+    EncodingError {
+        declared_encoding: String,
+        detected_encoding: Option<String>,
+        message: String,
+        had_errors: bool,
+    },
+
+    /// Required field is missing from a record
+    MissingRequiredField {
+        record_type: String,
+        record_xref: Option<String>,
+        field: String,
+    },
 }
 
 impl fmt::Display for GedcomError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             GedcomError::Io(err) => write!(f, "I/O error: {}", err),
-            GedcomError::FileNotFound(path) => write!(f, "File not found: {}", path),
+            GedcomError::FileNotFound(path) => {
+                writeln!(f, "File not found: '{}'", path)?;
+                write!(
+                    f,
+                    "  Hint: Check that the file path is correct and the file exists"
+                )
+            }
             GedcomError::ParseError {
                 line_number,
+                record_type,
+                field,
+                message,
+                context,
+            } => {
+                write!(f, "Parse error")?;
+                if let Some(line) = line_number {
+                    write!(f, " at line {}", line)?;
+                }
+                if let Some(rec_type) = record_type {
+                    write!(f, " in {} record", rec_type)?;
+                }
+                if let Some(fld) = field {
+                    write!(f, ", field '{}'", fld)?;
+                }
+                write!(f, ": {}", message)?;
+                if let Some(ctx) = context {
+                    write!(f, "\n  Context: {}", ctx)?;
+                }
+                Ok(())
+            }
+            GedcomError::InvalidStructure {
+                record_xref,
                 message,
             } => {
-                if let Some(line) = line_number {
-                    write!(f, "Parse error at line {}: {}", line, message)
-                } else {
-                    write!(f, "Parse error: {}", message)
+                write!(f, "Invalid GEDCOM structure")?;
+                if let Some(xref) = record_xref {
+                    write!(f, " in record {}", xref)?;
                 }
+                write!(f, ": {}", message)
             }
-            GedcomError::InvalidStructure(msg) => write!(f, "Invalid GEDCOM structure: {}", msg),
+            GedcomError::ValidationError {
+                record_type,
+                record_xref,
+                field,
+                message,
+            } => {
+                write!(f, "Validation error in {} record", record_type)?;
+                if let Some(xref) = record_xref {
+                    write!(f, " ({})", xref)?;
+                }
+                write!(f, ", field '{}': {}", field, message)
+            }
+            GedcomError::EncodingError {
+                declared_encoding,
+                detected_encoding,
+                message,
+                had_errors,
+            } => {
+                write!(
+                    f,
+                    "Character encoding error: declared as '{}', ",
+                    declared_encoding
+                )?;
+                if let Some(detected) = detected_encoding {
+                    write!(f, "detected as '{}', ", detected)?;
+                }
+                write!(f, "{}", message)?;
+                if *had_errors {
+                    write!(
+                        f,
+                        "\n  Warning: Some characters could not be converted correctly"
+                    )?;
+                }
+                Ok(())
+            }
+            GedcomError::MissingRequiredField {
+                record_type,
+                record_xref,
+                field,
+            } => {
+                write!(
+                    f,
+                    "Missing required field '{}' in {} record",
+                    field, record_type
+                )?;
+                if let Some(xref) = record_xref {
+                    write!(f, " ({})", xref)?;
+                }
+                Ok(())
+            }
         }
     }
 }
@@ -73,34 +180,118 @@ mod tests {
     #[test]
     fn test_file_not_found_display() {
         let err = GedcomError::FileNotFound("test.ged".to_string());
-        assert_eq!(format!("{}", err), "File not found: test.ged");
+        let msg = format!("{}", err);
+        assert!(msg.contains("File not found"));
+        assert!(msg.contains("test.ged"));
     }
 
     #[test]
     fn test_parse_error_with_line_number() {
         let err = GedcomError::ParseError {
             line_number: Some(42),
+            record_type: None,
+            field: None,
             message: "Invalid syntax".to_string(),
+            context: None,
         };
-        assert_eq!(format!("{}", err), "Parse error at line 42: Invalid syntax");
+        assert!(format!("{}", err).contains("line 42"));
+        assert!(format!("{}", err).contains("Invalid syntax"));
     }
 
     #[test]
     fn test_parse_error_without_line_number() {
         let err = GedcomError::ParseError {
             line_number: None,
+            record_type: None,
+            field: None,
             message: "Invalid syntax".to_string(),
+            context: None,
         };
-        assert_eq!(format!("{}", err), "Parse error: Invalid syntax");
+        assert!(format!("{}", err).contains("Parse error"));
+        assert!(format!("{}", err).contains("Invalid syntax"));
+    }
+
+    #[test]
+    fn test_parse_error_with_full_context() {
+        let err = GedcomError::ParseError {
+            line_number: Some(42),
+            record_type: Some("INDI".to_string()),
+            field: Some("NAME".to_string()),
+            message: "Invalid name format".to_string(),
+            context: Some("1 NAME /Invalid/Name/".to_string()),
+        };
+        let msg = format!("{}", err);
+        assert!(msg.contains("line 42"));
+        assert!(msg.contains("INDI"));
+        assert!(msg.contains("NAME"));
+        assert!(msg.contains("Invalid name format"));
+        assert!(msg.contains("Context"));
     }
 
     #[test]
     fn test_invalid_structure_display() {
-        let err = GedcomError::InvalidStructure("Missing required field".to_string());
-        assert_eq!(
-            format!("{}", err),
-            "Invalid GEDCOM structure: Missing required field"
-        );
+        let err = GedcomError::InvalidStructure {
+            record_xref: Some("@I1@".to_string()),
+            message: "Missing required field".to_string(),
+        };
+        let msg = format!("{}", err);
+        assert!(msg.contains("Invalid GEDCOM structure"));
+        assert!(msg.contains("@I1@"));
+        assert!(msg.contains("Missing required field"));
+    }
+
+    #[test]
+    fn test_validation_error_display() {
+        let err = GedcomError::ValidationError {
+            record_type: "INDI".to_string(),
+            record_xref: Some("@I1@".to_string()),
+            field: "NAME".to_string(),
+            message: "Name cannot be empty".to_string(),
+        };
+        let msg = format!("{}", err);
+        assert!(msg.contains("Validation error"));
+        assert!(msg.contains("INDI"));
+        assert!(msg.contains("@I1@"));
+        assert!(msg.contains("NAME"));
+        assert!(msg.contains("Name cannot be empty"));
+    }
+
+    #[test]
+    fn test_encoding_error_display() {
+        let err = GedcomError::EncodingError {
+            declared_encoding: "ANSEL".to_string(),
+            detected_encoding: Some("UTF-8".to_string()),
+            message: "Using UTF-8 fallback".to_string(),
+            had_errors: true,
+        };
+        let msg = format!("{}", err);
+        assert!(msg.contains("encoding error"));
+        assert!(msg.contains("ANSEL"));
+        assert!(msg.contains("UTF-8"));
+        assert!(msg.contains("Warning"));
+    }
+
+    #[test]
+    fn test_missing_required_field_display() {
+        let err = GedcomError::MissingRequiredField {
+            record_type: "INDI".to_string(),
+            record_xref: Some("@I1@".to_string()),
+            field: "NAME".to_string(),
+        };
+        let msg = format!("{}", err);
+        assert!(msg.contains("Missing required field"));
+        assert!(msg.contains("NAME"));
+        assert!(msg.contains("INDI"));
+        assert!(msg.contains("@I1@"));
+    }
+
+    #[test]
+    fn test_file_not_found_includes_hint() {
+        let err = GedcomError::FileNotFound("missing.ged".to_string());
+        let msg = format!("{}", err);
+        assert!(msg.contains("File not found"));
+        assert!(msg.contains("missing.ged"));
+        assert!(msg.contains("Hint"));
     }
 
     #[test]
@@ -117,11 +308,17 @@ mod tests {
 
         let err = GedcomError::ParseError {
             line_number: None,
+            record_type: None,
+            field: None,
             message: "test".to_string(),
+            context: None,
         };
         assert!(err.source().is_none());
 
-        let err = GedcomError::InvalidStructure("test".to_string());
+        let err = GedcomError::InvalidStructure {
+            record_xref: None,
+            message: "test".to_string(),
+        };
         assert!(err.source().is_none());
     }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -158,9 +158,36 @@ pub struct Gedcom {
     pub notes: Vec<NoteRecord>,
     pub multimedia: Vec<MultimediaRecord>,
     pub submitters: Vec<Submitter>,
+
+    /// Validation warnings encountered during parsing
+    /// These are non-fatal issues that don't prevent parsing but indicate
+    /// potential problems with the GEDCOM file
+    pub warnings: Vec<crate::error::GedcomError>,
 }
 
 impl Gedcom {
+    // ===== Validation Functions =====
+
+    /// Returns whether the GEDCOM file has any validation warnings
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use gedcom_rs::parse::{parse_gedcom, GedcomConfig};
+    ///
+    /// let gedcom = parse_gedcom("file.ged", &GedcomConfig::new())?;
+    /// if gedcom.has_warnings() {
+    ///     println!("File has {} validation warnings", gedcom.warnings.len());
+    ///     for warning in &gedcom.warnings {
+    ///         eprintln!("Warning: {}", warning);
+    ///     }
+    /// }
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn has_warnings(&self) -> bool {
+        !self.warnings.is_empty()
+    }
+
     // ===== Search Functions =====
 
     /// Find an individual by their cross-reference ID (xref)


### PR DESCRIPTION
## Summary

Implements comprehensive error message improvements to complete the final Version 0.2.0 goal from ROADMAP.md. This PR adds enhanced error types, better error messages, automatic validation, and non-fatal warning collection.

## Motivation

The Version 0.2.0 roadmap identified "Improved error messages" as a remaining goal. Previously:
- Error messages were generic with limited context
- No validation of GEDCOM data quality
- Encoding errors were only printed to stdout
- Users had no way to collect warnings without parsing failures

This PR provides clear, actionable feedback about GEDCOM file issues while allowing parsing to continue.

## Changes

### Enhanced Error Types (src/error.rs: +202 lines)

Added 3 new error variants:
- **ValidationError** - For data quality issues (missing names, empty families)
- **EncodingError** - For character encoding conversion problems  
- **MissingRequiredField** - For GEDCOM 5.5.1 required field violations

Enhanced existing errors:
- **ParseError** now includes `record_type`, `field`, and `context` for better debugging
- **InvalidStructure** now includes `record_xref` for identifying problematic records

### Improved Error Display

Error messages now include:
- Multi-line formatting with helpful hints
- Clear location indicators (line number, record type, field name)
- Context snippets showing the problematic code
- User-friendly descriptions

**Examples:**
```
File not found: 'missing.ged'
  Hint: Check that the file path is correct and the file exists

Parse error at line 42 in INDI record, field 'NAME': Invalid name format
  Context: 1 NAME /Invalid/Name/

Validation error in INDI record (@I1@), field 'NAME': Individual has no name
```

### Validation System (src/parse.rs: +107 lines)

- Added `warnings: Vec<GedcomError>` to Gedcom struct
- Automatic validation after parsing completes
- Non-fatal warnings allow parsing to continue
- Validates all record types:
  - **Individuals** - warns if no NAME (recommended field)
  - **Families** - warns if no HUSB/WIFE/CHIL (data quality)
  - **Submitters** - error if no NAME (required by GEDCOM 5.5.1)
  - **Repositories** - warns if no NAME (recommended)
  - **Multimedia** - error if no FILE (required)

### Encoding Error Tracking

- Captures character encoding conversion errors during file reading
- Adds warnings to `gedcom.warnings` when encoding issues occur
- Maintains backward compatibility with verbose mode
- Non-breaking - file still processes with warnings

### Helper Methods (src/types/mod.rs: +27 lines)

```rust
impl Gedcom {
    /// Returns whether the GEDCOM file has any validation warnings
    pub fn has_warnings(&self) -> bool {
        !self.warnings.is_empty()
    }
}
```

### Comprehensive Tests (tests/integration_tests.rs: +80 lines)

- 13 new error-specific unit tests
- 2 new integration tests for validation warnings
- Tests verify:
  - Error message formatting
  - Validation warning collection
  - Parsing continues despite warnings
  - Specific warning types are detected

## Breaking Changes

⚠️ **Minor breaking changes:**
- `ParseError` struct fields changed (added `record_type`, `field`, `context`)
- `InvalidStructure` changed from tuple to struct variant
- `Gedcom` struct has new `warnings` field (breaks struct construction)

These are acceptable because:
1. Error types are primarily used for display, not pattern matching
2. `Gedcom` is typically created by `parse_gedcom()`, not directly
3. No users exist yet (pre-1.0)

## Usage Example

```rust
use gedcom_rs::parse::{parse_gedcom, GedcomConfig};

let gedcom = parse_gedcom("family.ged", &GedcomConfig::new())?;

// Check for validation warnings
if gedcom.has_warnings() {
    println!("File has {} warnings:", gedcom.warnings.len());
    for warning in &gedcom.warnings {
        eprintln!("Warning: {}", warning);
    }
}

// All records are still accessible
println!("Found {} individuals", gedcom.individuals.len());
```

## Verification

- ✅ All 291 tests passing (217 + 8 + 25 + 23 + 18)
- ✅ No clippy warnings (`cargo clippy -- -D warnings`)
- ✅ Code properly formatted (`cargo fmt`)
- ✅ Successfully builds
- ✅ Non-breaking implementation (warnings don't prevent parsing)

## Version 0.2.0 Status

This PR completes all Version 0.2.0 goals:
- ✅ Core FAM record parsing
- ✅ Complete FAM record parsing
- ✅ Full INDIVIDUAL_RECORD implementation
- ✅ Complete SOUR record parsing
- ✅ Complete NOTE record parsing
- ✅ Complete OBJE record parsing
- ✅ Complete REPO record parsing
- ✅ **Improved error messages** ← COMPLETED by this PR
- ✅ Performance optimizations

## Implementation Approach

Focused on low and medium priority improvements:
- **Low complexity**: Enhanced error types and display messages
- **Medium complexity**: Validation system with warning collection
- **Medium complexity**: Encoding error capture
- **Deferred**: Line number threading (high complexity, lower ROI)

## Testing

Run tests:
```bash
cargo test
cargo clippy -- -D warnings
cargo fmt --check
```

All commands pass successfully.